### PR TITLE
Set up CODEOWNERS file to enforce pull request reviews 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Code Owners file to enforce reviews for future collaborators
+* @mdjc


### PR DESCRIPTION
Adds a .github/CODEOWNERS file assigning @mdjc as the default code owner.

While review approvals are not required currently, this prepares the repository to enforce code owner approvals if collaborators are added in the future.

This supports maintaining clean and reviewed code as the project evolves.